### PR TITLE
feat(typedFormControl): add validator[] to typedFormControl parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13544,8 +13544,6 @@
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -14218,7 +14216,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -14234,19 +14232,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14261,7 +14259,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -14279,7 +14277,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -35875,8 +35873,6 @@
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "bundled": true,
           "dev": true
         },
@@ -36388,7 +36384,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -36402,17 +36398,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -36425,7 +36421,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -36440,7 +36436,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/projects/forms/CHANGELOG.md
+++ b/projects/forms/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2021-06-29
+### Fixed
+- typedFormControl now accepts `ValidatorFn[]` or `AsyncValidatorFn[]` like default Angular FormControl
+
 ## [1.1.1] - 2021-06-05
 ### Fixed
 -   the form.keys was mistakenly an `Array` while advertised as a `Record<keyof T, string>`

--- a/projects/forms/src/lib/forms-typed.ts
+++ b/projects/forms/src/lib/forms-typed.ts
@@ -59,8 +59,8 @@ export interface TypedFormControl<K> extends FormControl, AbstractControl {
  */
 export function typedFormControl<T>(
   v?: T | { value: T; disabled: boolean },
-  validatorsOrOptions?: ValidatorFn | AbstractControlOptions,
-  asyncValidators?: AsyncValidatorFn
+  validatorsOrOptions?: ValidatorFn | AbstractControlOptions | ValidatorFn[],
+  asyncValidators?: AsyncValidatorFn | AsyncValidatorFn[]
 ): TypedFormControl<T> {
   return new FormControl(v, validatorsOrOptions, asyncValidators);
 }


### PR DESCRIPTION
standard Angular AbstractFormControl accepts ValidatorFn[] as
validatorsOrOptions parameter  and AsyncValidatorFn[] as
asyncValidators parameter whereas typedFormControl was missing
this option so far